### PR TITLE
Add attr reference

### DIFF
--- a/test/swift_class_test.exs
+++ b/test/swift_class_test.exs
@@ -89,5 +89,12 @@ defmodule SwiftClassTest do
 
       assert output == parse(input)
     end
+
+    test "parses attr value references" do
+      input = "foo(attr(bar))"
+      output = [["foo", [["bar", :attr]], nil]]
+
+      assert output == parse(input)
+    end
   end
 end


### PR DESCRIPTION
`attr(<name>)` will need to be treated differently than the normal function call. We are treating this as a value type of `attr` represented as a two-dimensional tuple: `["<name>", :attr]`